### PR TITLE
fix: add Electron entry (main + preload), placeholder icon and initia…

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,0 +1,42 @@
+const { app, BrowserWindow, nativeTheme } = require('electron')
+const path = require('path')
+
+const isDev = process.env.NODE_ENV === 'development' || !!process.env.VITE_DEV_SERVER_URL
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    show: true,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false
+    }
+  })
+
+  if (isDev && process.env.VITE_DEV_SERVER_URL) {
+    win.loadURL(process.env.VITE_DEV_SERVER_URL)
+    win.webContents.openDevTools()
+  } else {
+    win.loadFile(path.join(__dirname, 'dist', 'index.html'))
+  }
+
+  return win
+}
+
+app.whenReady().then(() => {
+  // prefer dark mode that matches system
+  if (nativeTheme.shouldUseDarkColors) nativeTheme.themeSource = 'dark'
+  createWindow()
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow()
+  })
+})
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit()
+})
+
+// Exported for testing (do not call in production test environment)
+module.exports = { createWindow }

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,8 @@
+const { contextBridge, ipcRenderer } = require('electron')
+
+// Minimal secure bridge — extend as needed for IPC between renderer <-> main
+contextBridge.exposeInMainWorld('electronAPI', {
+  send: (channel, ...args) => ipcRenderer.send(channel, ...args),
+  on: (channel, cb) => ipcRenderer.on(channel, (event, ...args) => cb(...args)),
+  versions: process.versions
+})

--- a/public/pac.ico
+++ b/public/pac.ico
@@ -1,0 +1,1 @@
+ICON-PLACEHOLDER - replace with real .ico for Windows builds

--- a/src/electron/__tests__/electron-files.test.js
+++ b/src/electron/__tests__/electron-files.test.js
@@ -1,0 +1,27 @@
+import { test, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+
+const root = path.resolve(process.cwd())
+
+test('electron entry files exist and export createWindow', () => {
+  const mainPath = path.join(root, 'main.js')
+  const preloadPath = path.join(root, 'preload.js')
+
+  expect(fs.existsSync(mainPath)).toBe(true)
+  expect(fs.existsSync(preloadPath)).toBe(true)
+
+  const mainContent = fs.readFileSync(mainPath, 'utf8')
+  expect(mainContent).toContain('createWindow')
+
+  const preloadContent = fs.readFileSync(preloadPath, 'utf8')
+  expect(preloadContent).toContain('contextBridge')
+})
+
+test('package.json references electron entry files and icon', () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'))
+  expect(pkg.main).toBe('main.js')
+  expect(pkg.build).toBeTruthy()
+  expect(pkg.build.files).toEqual(expect.arrayContaining(['dist/**/*', 'main.js', 'preload.js', 'package.json', 'public/**/*']))
+  expect(fs.existsSync(path.join(root, 'public', 'pac.ico'))).toBe(true)
+})


### PR DESCRIPTION
…l electron tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Electron main and preload entry points and a placeholder Windows icon to enable basic app boot in dev and prod. Includes initial tests to ensure files exist and package.json is correctly configured.

- **New Features**
  - main.js creates a BrowserWindow, exports createWindow, loads the Vite dev URL in development or dist/index.html in production, and prefers dark mode with standard macOS lifecycle handling.
  - preload.js exposes a minimal, secure electronAPI (send, on, versions) with contextIsolation and no nodeIntegration.
  - Adds pac.ico placeholder; tests verify entry files and package.json main/build.files include required paths.

<sup>Written for commit 8dfe979fd69e2158d3bb86963fe5b66dc455d5e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

